### PR TITLE
remove intermediate base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,26 @@
-FROM travix/base-debian-git-jre8:latest
+FROM debian:jessie
 
 MAINTAINER Travix
+
+# install dependencies
+RUN apt-get update \
+    && apt-get install -y \
+        curl \
+        unzip \
+        make \
+        git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && git config --global core.preloadindex true \
+    && git config --global gc.auto 256
+
+# install jre 8 dependencies
+RUN echo "deb http://http.debian.net/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list \
+    && apt-get update \
+    && apt-get install -y \
+        openjdk-8-jre-headless \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # install docker (based on https://github.com/docker-library/docker/blob/587b66d54a69996fc765c9671eb9bc8740172f2d/17.04/Dockerfile)
 


### PR DESCRIPTION
Don't base on travix base images, but use debian jessie directly.